### PR TITLE
fix the wp-consent-api-url path

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -7,7 +7,7 @@
 
 namespace Altis\Consent\API;
 
-defined( 'WP_CONSENT_API_URL' ) or define( 'WP_CONSENT_API_URL', plugin_dir_url( __FILE__ ) );
+defined( 'WP_CONSENT_API_URL' ) or define( 'WP_CONSENT_API_URL', plugin_dir_url( dirname( __FILE__ ) ) );
 defined( 'WP_CONSENT_API_VERSION' ) or define( 'WP_CONSENT_API_VERSION', get_plugin_data()['Version'] ) . ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '-' . time() : '';
 
 /**


### PR DESCRIPTION
this fixes the path to the consent api js file. previously it was pointing to /inc/src/wp-consent-api.js