### PR TITLE
Revert "Fix filter callbacks"

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -44,34 +44,28 @@ function enqueue_api() {
 	 *
 	 * @param bool $waitfor_consent_hook Wait until consent has been given.
 	 */
-	$waitfor_consent_hook = apply_filters( 'wp_consent_api_waitfor_consent_hook', '__return_false' );
+	$waitfor_consent_hook = apply_filters( 'wp_consent_api_waitfor_consent_hook', false );
 
 	/**
 	 * The consent cookie prefix. Defaults to wp_consent_.
 	 *
 	 * @param string $prefix The active cookie prefix.
 	 */
-	$prefix = apply_filters( 'wp_consent_cookie_prefix', function() {
-		return 'wp_consent';
-	} );
+	$prefix = apply_filters( 'wp_consent_cookie_prefix', 'wp_consent' );
 
 	/**
 	 * The active consent type. Defaults to optin.
 	 *
 	 * @param string $consent_type The active consent type.
 	 */
-	$consent_type = apply_filters( 'wp_get_consent_type', function() {
-		return 'optin';
-	} );
+	$consent_type = apply_filters( 'wp_get_consent_type', 'optin' );
 
 	/**
 	 * The list of active consent types.
 	 *
 	 * @param array $consent_types The available consent types.
 	 */
-	$consent_types = apply_filters( 'wp_consent_types', function() {
-		return [ 'optin', 'optout' ];
-	} );
+	$consent_types = apply_filters( 'wp_consent_types', [ 'optin', 'optout' ] );
 
 	// Send the variables and filterable values to the javascript consent API.
 	wp_localize_script(


### PR DESCRIPTION
Reverts humanmade/consent-api-js#5

This was an unnecessary change and introduces some bugs when using without the Altis Consent plugin. I guess I was tired while reviewing that day.