### PR TITLE
Update patch version to ensure cache is busted

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -25,8 +25,8 @@
  * Plugin Name:       WP Consent API JS
  * Plugin URI:        https://github.com/humanmade/consent-api-js
  * Description:       Forks the JavaScript Consent API in rlankhorst/wp-consent-level-api. Consent Level API to read and register the current consent level for cookie management and improving compliance with privacy laws.
- * Version:           1.0.2
- * Author:            RogierLankhorst and Human Made
+ * Version:           1.0.6
+ * Author:            Rogier Lankhorst and Human Made
  * Author URI:        https://humanmade.com
  * Requires at least: 5.0
  * Requires PHP:      5.6


### PR DESCRIPTION
The JS file version is read from the WP plugin header but that hasn't been updated since 1.0.2 by mistake. This updates it to 1.0.6 so we can make a new patch release that will bust the cache.